### PR TITLE
Add selected track Arm/Solo/Mute functionality

### DIFF
--- a/YourControllerName/MIDI_Map.py
+++ b/YourControllerName/MIDI_Map.py
@@ -103,6 +103,10 @@ CLIPNOTEMAP = ((-1, -1, -1, -1, -1, -1, -1, -1), #Row 1
 
 # Track Control
 MASTERSEL = -1 #Master track select
+SELTRACKREC = -1 # Arm Selected Track
+SELTRACKSOLO = -1 # Solo Selected Track
+SELTRACKMUTE = -1 # Mute Selected Track
+
 TRACKSTOP = (-1, #Track 1 Clip Stop
              -1, #Track 2
              -1, #Track 3

--- a/YourControllerName/YourControllerName.py
+++ b/YourControllerName/YourControllerName.py
@@ -130,6 +130,9 @@ class YourControllerName(ControlSurface):
         self._mixer.set_crossfader_control(self._ctrl_map[CROSSFADER])
         self._mixer.set_prehear_volume_control(self._ctrl_map[CUELEVEL])
         self._mixer.master_strip().set_volume_control(self._ctrl_map[MASTERVOLUME])
+        self._mixer.selected_strip().set_arm_button(self._note_map[SELTRACKREC])
+        self._mixer.selected_strip().set_solo_button(self._note_map[SELTRACKSOLO])
+        self._mixer.selected_strip().set_mute_button(self._note_map[SELTRACKMUTE])
         for track in range(8):
             strip = self._mixer.channel_strip(track)
             strip.name = 'Channel_Strip_' + str(track)


### PR DESCRIPTION
This PR adds mappings for manipulating currently selected track. This is useful especially when using a midi foot controller, where you usually don't have a row of buttons and assigning each button to a particular track is not practical. 